### PR TITLE
Added ov option for multi-desktop setup

### DIFF
--- a/animwall
+++ b/animwall
@@ -48,6 +48,7 @@ wrapped()
     -nf \
     -b \
     -un \
+    -ov \
     -- nice -n "${__nice_value}" mpv \
     -wid WID "$1" \
     --no-osc \


### PR DESCRIPTION
I'm using XFCE4 with multiple desktops and found that without the -ov option xwinwrap will not set the background at both desktops